### PR TITLE
Support MEAI UriContent type

### DIFF
--- a/src/GeminiDotnet.Extensions.AI/MEAIToGeminiMapper.cs
+++ b/src/GeminiDotnet.Extensions.AI/MEAIToGeminiMapper.cs
@@ -1,6 +1,7 @@
 using GeminiDotnet.ContentGeneration;
 using GeminiDotnet.ContentGeneration.FunctionCalling;
 using GeminiDotnet.Embeddings;
+using Microsoft.Extensions.AI;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using System.Text.Json;
@@ -201,6 +202,7 @@ internal static class MEAIToGeminiMapper
             {
                 MEAI.TextContent textContent => CreateTextPart(textContent),
                 MEAI.DataContent dataContent => CreateInlineDataPart(dataContent),
+                MEAI.UriContent uriContent => CreateFileDataPart(uriContent),
                 MEAI.FunctionCallContent functionCall => CreateFunctionCallPart(functionCall),
                 MEAI.FunctionResultContent functionResult => CreateFunctionResponsePart(functionResult),
                 _ => ThrowUnsupportedContentException(content),
@@ -236,6 +238,15 @@ internal static class MEAIToGeminiMapper
                 return new Part
                 {
                     InlineData = new Blob { Data = dataContent.Data, MimeType = dataContent.MediaType }
+                };
+            }
+
+
+            static Part CreateFileDataPart(UriContent uriContent)
+            {
+                return new Part
+                {
+                    FileData = new FileData { Uri = uriContent.Uri, MimeType = uriContent.MediaType }
                 };
             }
 

--- a/src/GeminiDotnet/ContentGeneration/FileData.cs
+++ b/src/GeminiDotnet/ContentGeneration/FileData.cs
@@ -7,9 +7,10 @@ namespace GeminiDotnet.ContentGeneration;
 /// </summary>
 public sealed record FileData
 {
-    [JsonPropertyName("mime_type")]
-    public required string MimeType { get; init; }
+    [JsonPropertyName("mimeType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MimeType { get; init; }
 
-    [JsonPropertyName("uri")]
+    [JsonPropertyName("fileUri")]
     public required Uri Uri { get; init; }
 }


### PR DESCRIPTION
Maps to `FileData`. MEAI requires a MIME type but Gemini doesn't which is a little unfortunate.

Also fixes the property names and requirements.