### PR TITLE
Added missing definition for safety filters

### DIFF
--- a/src/GeminiDotnet.Extensions.AI/GeminiToMEAIMapper.cs
+++ b/src/GeminiDotnet.Extensions.AI/GeminiToMEAIMapper.cs
@@ -37,6 +37,11 @@ internal static class GeminiToMEAIMapper
             FinishReason.Stop => ChatFinishReason.Stop,
             FinishReason.MaxTokens => ChatFinishReason.Length,
             FinishReason.Safety => ChatFinishReason.ContentFilter,
+            FinishReason.SPII => ChatFinishReason.ContentFilter,
+            FinishReason.BlockedReasonUnspecified => ChatFinishReason.ContentFilter,
+            FinishReason.Recitation => ChatFinishReason.ContentFilter,
+            FinishReason.ProhibitedContent => ChatFinishReason.ContentFilter,
+
             _ => null
         };
     }

--- a/src/GeminiDotnet/ContentGeneration/FinishReason.cs
+++ b/src/GeminiDotnet/ContentGeneration/FinishReason.cs
@@ -43,6 +43,24 @@ public enum FinishReason
     Recitation,
 
     /// <summary>
+    /// The prompt was blocked because it was flagged for containing the prohibited contents, usually CSAM.
+    /// </summary>
+    [JsonStringEnumMemberName("PROHIBITED_CONTENT")]
+    ProhibitedContent,
+
+    /// <summary>
+    /// The reason for blocking the prompt is unspecified.
+    /// </summary>
+    [JsonStringEnumMemberName("BLOCKED_REASON_UNSPECIFIED")]
+    BlockedReasonUnspecified,
+
+    /// <summary>
+    /// The token generation was stopped because the response was flagged for Sensitive Personally Identifiable Information (SPII) content..
+    /// </summary>
+    [JsonStringEnumMemberName("SPII")]
+    SPII,
+
+    /// <summary>
     /// All other reasons that stopped token generation.
     ///</summary>
     [JsonStringEnumMemberName("OTHER")]


### PR DESCRIPTION
Updated the `GeminiToMEAIMapper` class to include new mappings for `FinishReason.SPII`, `FinishReason.BlockedReasonUnspecified`, `FinishReason.Recitation`, and `FinishReason.ProhibitedContent` to `ChatFinishReason.ContentFilter`.

Modified the `FinishReason` enum to add `ProhibitedContent`, `BlockedReasonUnspecified`, and `SPII`, with appropriate XML documentation comments for clarity.