### PR TITLE
fix: use response id to populate message id property on response updates

### DIFF
--- a/src/GeminiDotnet.Extensions.AI/GeminiToMEAIMapper.cs
+++ b/src/GeminiDotnet.Extensions.AI/GeminiToMEAIMapper.cs
@@ -23,6 +23,7 @@ internal static class GeminiToMEAIMapper
             RawRepresentation = response,
             AdditionalProperties = null,
             ResponseId = response.ResponseId,
+            MessageId = response.ResponseId,
             ConversationId = null,
             CreatedAt = createdAt,
             FinishReason = CreateMappedChatFinishReason(candidate.FinishReason),


### PR DESCRIPTION
Closes #43 

This pull request introduces a minor update to the `CreateMappedChatResponseUpdate` method in the `GeminiToMEAIMapper.cs` file. The change adds a mapping for the `MessageId` property, assigning it the value of `response.ResponseId`. This ensures that the `MessageId` field is properly populated when creating a chat response update.

* Added assignment of `MessageId` to `response.ResponseId` in the `CreateMappedChatResponseUpdate` method (`GeminiToMEAIMapper.cs`).