### PR TITLE
fix: use system instructions from chat options if given

### DIFF
--- a/src/GeminiDotnet.Extensions.AI/MEAIToGeminiMapper.cs
+++ b/src/GeminiDotnet.Extensions.AI/MEAIToGeminiMapper.cs
@@ -44,7 +44,9 @@ internal static class MEAIToGeminiMapper
 
         return new GenerateContentRequest
         {
-            SystemInstruction = systemInstruction,
+            SystemInstruction = options?.Instructions is not null
+              ? CreateMappedContent(new MEAI.ChatMessage(MEAI.ChatRole.System, options.Instructions))
+              : systemInstruction,
             GenerationConfiguration = CreateMappedGenerationConfiguration(options),
             CachedContent = null,
             Contents = contents,


### PR DESCRIPTION
This pull request updates the logic for setting the `SystemInstruction` field in the `CreateMappedGenerateContentRequest` method. Now, if `options?.Instructions` is provided, it creates a mapped system instruction using those instructions; otherwise, it falls back to the original `systemInstruction`.

* Improved system instruction mapping: The `SystemInstruction` field is now set to a mapped content when `options.Instructions` is provided, ensuring that custom instructions are properly included in the request.