### PR TITLE
Add support for ImageConfiguration in Extensions.AI

### DIFF
--- a/src/GeminiDotnet.Extensions.AI/GeminiAdditionalProperties.cs
+++ b/src/GeminiDotnet.Extensions.AI/GeminiAdditionalProperties.cs
@@ -5,4 +5,6 @@ public static class GeminiAdditionalProperties
     public const string ThinkingConfiguration = "thinkingConfig";
     
     public const string ResponseModalities = "responseModalities";
+
+    public const string ImageConfiguration = "imageConfig";
 }

--- a/src/GeminiDotnet.Extensions.AI/MEAIToGeminiMapper.cs
+++ b/src/GeminiDotnet.Extensions.AI/MEAIToGeminiMapper.cs
@@ -129,12 +129,22 @@ internal static class MEAIToGeminiMapper
                     responseModalitiesObj as IReadOnlyList<ResponseModality> ?? responseModalitiesList.ToList();
             }
 
+            ImageConfiguration? imageConfiguration = null;
+
+            if (options.AdditionalProperties?.TryGetValue(GeminiAdditionalProperties.ImageConfiguration,
+                   out var imageConfigObj) is true
+               && imageConfigObj is ImageConfiguration imageConfig)
+            {
+                imageConfiguration = imageConfig;
+            }
+
             var configuration = new GenerationConfiguration
             {
                 StopSequences = options.StopSequences is null ? null : [.. options.StopSequences],
                 ResponseMimeType = CreateMappedResponseMimeType(options.ResponseFormat),
                 ResponseJsonSchema = CreateMappedResponseSchema(options.ResponseFormat),
                 ResponseModalities = responseModalities,
+                ImageConfiguration = imageConfiguration,
                 CandidateCount = null,
                 MaxOutputTokens = options.MaxOutputTokens,
                 Temperature = options.Temperature,

--- a/src/GeminiDotnet/V1Beta/ImageConfiguration.cs
+++ b/src/GeminiDotnet/V1Beta/ImageConfiguration.cs
@@ -9,12 +9,19 @@ public sealed record ImageConfiguration
 {
     /// <summary>
     /// Optional. The aspect ratio of the image to generate. Supported aspect ratios: 1:1,
-    /// 2:3, 3:2, 3:4, 4:3, 9:16, 16:9, 21:9.
+    /// 2:3, 3:2, 3:4, 4:3, 5:4, 4:5, 9:16, 16:9, 21:9.
     /// If not specified, the model will choose a default aspect ratio based on any
     /// reference images provided.
     /// </summary>
     [JsonPropertyName("aspectRatio")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? AspectRatio { get; init; }
+
+    /// <summary>
+    /// Optional. Supported by gemini-3-pro-image. Allowed values: 1K, 2K, 4K.
+    /// </summary>
+    [JsonPropertyName("image_size")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public string? ImageSize { get; init; }
 }
 


### PR DESCRIPTION
Added possiblity to pass optional image config parameters to image models like gemini-2.5-flash-image and gemini-3-pro-image-preview.

- Added logic to parse and map `ImageConfiguration` from `AdditionalProperties`.
- Updated `GenerationConfiguration` to include `ImageConfiguration`.
- Expanded supported aspect ratios in `ImageConfiguration` to include `5:4` and `4:5`.
- Introduced a new `ImageSize` property in `ImageConfiguration` for specifying resolutions (e.g., `1K`, `2K`, `4K`).